### PR TITLE
MSWindows-friendly patch command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,7 @@ if (BUILD_OGRE)
                 DEPENDS ogredeps
                 GIT_REPOSITORY https://github.com/OGRECave/ogre.git
                 GIT_TAG v1.11.6
-                PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/patches/scriptlexer.patch
+                PATCH_COMMAND patch --strip=1 --input=${CMAKE_SOURCE_DIR}/patches/scriptlexer.patch
                 CMAKE_ARGS
                 -DCMAKE_INSTALL_PREFIX=${DEPENDENCIES_OUTPUT_DIR}
                 -DOGRE_DEPENDENCIES_DIR=${DEPENDENCIES_OUTPUT_DIR}


### PR DESCRIPTION
The classic `patch -pN <...` syntax is unreliable on MSWindows, it may open another console window instead of reading stdin. Observed on Win10 Home x64 using gnuwin32-patch, see http://gnuwin32.sourceforge.net/packages/patch.htm