### PR TITLE
:wrench: Download dependencies instead of cloning the git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ build
 build_x86
 build_x64
 cmake-build-debug
-
+tmp/
 cmake-build-release/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@
 
 cmake_minimum_required(VERSION 3.2)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW)
+endif ()
+
 
 # ------------------------------------------------------------------------------------------------#
 # The intention of this script is to provide a simple solution for building all dependencies

--- a/angelscript/CMakeLists.txt
+++ b/angelscript/CMakeLists.txt
@@ -1,6 +1,7 @@
 ExternalProject_Add(
         angelscript
-        GIT_REPOSITORY https://github.com/AnotherFoxGuy/angelscript.git
+        URL https://github.com/AnotherFoxGuy/angelscript/archive/39d73b9e5e728c997019ec02cbbfa5bef9cf59e0.tar.gz
+        URL_MD5 ffe9a7552d9b188318b270cb8b483bb9
         CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${DEPENDENCIES_OUTPUT_DIR}
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/caelum/CMakeLists.txt
+++ b/caelum/CMakeLists.txt
@@ -15,7 +15,8 @@ endif ()
 ExternalProject_Add(
         caelum
         DEPENDS ogre
-        GIT_REPOSITORY https://github.com/RigsOfRods/ogre-caelum
+        URL https://github.com/RigsOfRods/ogre-caelum/archive/70fcf62f306288c9472cc03a42367c9625c839ea.tar.gz
+        URL_MD5 6fa41168cb93d67e7169d0e8e2d73f24
         CMAKE_ARGS
         -DCaelum_BUILD_SAMPLES=FALSE
         -DINSTALL_OGRE_PLUGIN=OFF

--- a/curl/CMakeLists.txt
+++ b/curl/CMakeLists.txt
@@ -1,9 +1,7 @@
 ExternalProject_Add(
         curl
-        GIT_REPOSITORY https://github.com/curl/curl.git
-        GIT_TAG curl-7_85_0
-        GIT_SHALLOW TRUE
-        GIT_PROGRESS TRUE
+        URL https://github.com/curl/curl/releases/download/curl-7_86_0/curl-7.86.0.tar.gz
+        URL_MD5 f44246e7c13cd91f07095fe63c06353c
         CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${DEPENDENCIES_OUTPUT_DIR}
         -DBUILD_CURL_TESTS=OFF

--- a/fmt/CMakeLists.txt
+++ b/fmt/CMakeLists.txt
@@ -1,9 +1,7 @@
 ExternalProject_Add(
-        fmt
-        GIT_REPOSITORY https://github.com/fmtlib/fmt
-        GIT_TAG 8.0.1
-        GIT_SHALLOW TRUE
-        GIT_PROGRESS TRUE
+        fmt 
+        URL https://github.com/fmtlib/fmt/releases/download/9.1.0/fmt-9.1.0.zip
+        URL_MD5 6133244fe8ef6f75c5601e8069b37b04
         CMAKE_ARGS
         -DFMT_TEST=OFF
         -DCMAKE_INSTALL_PREFIX=${DEPENDENCIES_OUTPUT_DIR}

--- a/mygui/CMakeLists.txt
+++ b/mygui/CMakeLists.txt
@@ -1,9 +1,8 @@
 ExternalProject_Add(
         mygui
         DEPENDS ogre
-        GIT_REPOSITORY https://github.com/MyGUI/mygui.git
-        GIT_TAG MyGUI3.4.0
-        GIT_PROGRESS TRUE
+        URL https://github.com/MyGUI/mygui/archive/refs/tags/MyGUI3.4.0.tar.gz
+        URL_MD5 30e64cdb3dc09a209259a5ffd13dc2ab
         CMAKE_ARGS
         -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON
         -DCMAKE_PREFIX_PATH=${DEPENDENCIES_OUTPUT_DIR}

--- a/ogre/CMakeLists.txt
+++ b/ogre/CMakeLists.txt
@@ -1,9 +1,8 @@
 # First build the required dependencies for Ogre itself. They are provided in a dedicated repository.
 ExternalProject_Add(
         ogredeps
-        GIT_REPOSITORY https://github.com/AnotherFoxGuy/ogredeps.git
-        GIT_SHALLOW TRUE
-        GIT_PROGRESS TRUE
+        URL https://github.com/AnotherFoxGuy/ogredeps/archive/17f4c583c82559074a96f1436670a4f10961b9d9.tar.gz
+        URL_MD5 d5425da9f4ffa9f24dd021e32a8665ad
         CMAKE_ARGS
         -DOGREDEPS_BUILD_AMD_QBS=OFF
         -DOGREDEPS_BUILD_NVIDIA_NVAPI=OFF
@@ -30,9 +29,8 @@ endif ()
 ExternalProject_Add(
         ogre
         DEPENDS ogredeps
-        GIT_REPOSITORY https://github.com/OGRECave/ogre.git
-        GIT_TAG v1.11.6
-        GIT_PROGRESS TRUE
+        URL https://github.com/OGRECave/ogre/archive/refs/tags/v1.11.6.tar.gz
+        URL_MD5 36ca3915aa41a0351bdf08b3953e9ae2
         PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/scriptlexer.patch
         CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${DEPENDENCIES_OUTPUT_DIR}

--- a/openal/CMakeLists.txt
+++ b/openal/CMakeLists.txt
@@ -1,9 +1,8 @@
 
 ExternalProject_Add(
         openal
-        GIT_REPOSITORY https://github.com/kcat/openal-soft.git
-        GIT_SHALLOW TRUE
-        GIT_PROGRESS TRUE
+        URL https://github.com/kcat/openal-soft/archive/refs/tags/1.22.2.tar.gz
+        URL_MD5 2d660bff2a16128bc7e894b1254d3783
         CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${DEPENDENCIES_OUTPUT_DIR}
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/pagedgeometry/CMakeLists.txt
+++ b/pagedgeometry/CMakeLists.txt
@@ -14,7 +14,8 @@ endif ()
 ExternalProject_Add(
         pagedgeometry
         DEPENDS ogre
-        GIT_REPOSITORY https://github.com/RigsOfRods/ogre-pagedgeometry.git
+        URL https://github.com/RigsOfRods/ogre-pagedgeometry/archive/9b4ee07dd7a884c667fc4051523b26b746bbd2c7.tar.gz
+        URL_MD5 5514a85cccd4132594d17582f9273047
         CMAKE_ARGS
         -DPAGEDGEOMETRY_BUILD_SAMPLES=OFF
         -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/OgreDependencies/;${DEPENDENCIES_OUTPUT_DIR}

--- a/rapidjson/CMakeLists.txt
+++ b/rapidjson/CMakeLists.txt
@@ -1,6 +1,7 @@
 ExternalProject_Add(
      RapidJSON
-     GIT_REPOSITORY https://github.com/Tencent/rapidjson
+     URL https://github.com/Tencent/rapidjson/archive/06d58b9e848c650114556a23294d0b6440078c61.tar.gz
+     URL_MD5 8109e8c5e82864476802d15f89419328
      CMAKE_ARGS
      -DCMAKE_INSTALL_PREFIX=${DEPENDENCIES_OUTPUT_DIR}
      -DINCLUDE_INSTALL_DIR=${DEPENDENCIES_OUTPUT_DIR}/include # rapidjson will add "rapidjson" subdirectory

--- a/socketw/CMakeLists.txt
+++ b/socketw/CMakeLists.txt
@@ -2,7 +2,8 @@ set(SOCKETW_SOURCE_DIR ${CMAKE_BINARY_DIR}/Source/socketw)
 
 ExternalProject_Add(
         socketw
-        GIT_REPOSITORY https://github.com/RigsOfRods/socketw.git
+        URL https://github.com/RigsOfRods/socketw/archive/refs/tags/3.11.0.tar.gz
+        URL_MD5 fc28cf0cc7f3497c4315c0e5fd37eb91
         PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/sw_config.h ${SOCKETW_SOURCE_DIR}/src/sw_config.h
         CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${DEPENDENCIES_OUTPUT_DIR}


### PR DESCRIPTION
This helps with the reproducibility of the builds, and reduces the time to download the deps