### PR TITLE
Build fix: OgreOverlay bogus libs 'debug' and 'optimized'

### DIFF
--- a/ogre/CMakeLists.txt
+++ b/ogre/CMakeLists.txt
@@ -44,6 +44,7 @@ ExternalProject_Add(
         URL https://github.com/OGRECave/ogre/archive/refs/tags/v1.11.6.tar.gz
         URL_MD5 36ca3915aa41a0351bdf08b3953e9ae2
         PATCH_COMMAND ${PATCH_TOOL_SCRIPT} ${CMAKE_CURRENT_SOURCE_DIR}/scriptlexer.patch
+        PATCH_COMMAND ${PATCH_TOOL_SCRIPT} ${CMAKE_CURRENT_SOURCE_DIR}/overlay-cmakelists.patch
         CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${DEPENDENCIES_OUTPUT_DIR}
         -DOGRE_DEPENDENCIES_DIR=${DEPENDENCIES_OUTPUT_DIR}

--- a/ogre/overlay-cmakelists.patch
+++ b/ogre/overlay-cmakelists.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1ed6460..0562d29 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,7 +21,7 @@ file(GLOB SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+ # setup target
+ add_library(OgreOverlay ${OGRE_COMP_LIB_TYPE} ${HEADER_FILES} ${SOURCE_FILES} ${PLATFORM_HEADER_FILES} ${PLATFORM_SOURCE_FILES})
+ set_target_properties(OgreOverlay PROPERTIES VERSION ${OGRE_SOVERSION} SOVERSION ${OGRE_SOVERSION})
+-target_link_libraries(OgreOverlay PUBLIC OgreMain PRIVATE "${FREETYPE_LIBRARIES}" ZLIB::ZLIB)
++target_link_libraries(OgreOverlay PUBLIC OgreMain PRIVATE ${FREETYPE_LIBRARIES} ZLIB::ZLIB)
+ target_include_directories(OgreOverlay PUBLIC
+   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+   $<INSTALL_INTERFACE:include/OGRE/Overlay>


### PR DESCRIPTION
those are cmake keywords that are treated literally due to `""` around `{FREETYPE_LIBRARIES}`

related: https://github.com/OGRECave/ogre/issues/843