### PR TITLE
Fixed FreeImage build under MSVC

### DIFF
--- a/ogre/CMakeLists.txt
+++ b/ogre/CMakeLists.txt
@@ -15,6 +15,7 @@ ExternalProject_Add(
         ogredeps
         URL https://github.com/AnotherFoxGuy/ogredeps/archive/17f4c583c82559074a96f1436670a4f10961b9d9.tar.gz
         URL_MD5 d5425da9f4ffa9f24dd021e32a8665ad
+        PATCH_COMMAND ${PATCH_TOOL_SCRIPT} ${CMAKE_CURRENT_SOURCE_DIR}/ogredeps-freeimage-binaryfunction.patch
         CMAKE_ARGS
         -DOGREDEPS_BUILD_AMD_QBS=OFF
         -DOGREDEPS_BUILD_NVIDIA_NVAPI=OFF

--- a/ogre/ogredeps-freeimage-binaryfunction.patch
+++ b/ogre/ogredeps-freeimage-binaryfunction.patch
@@ -1,0 +1,13 @@
+diff --git a/src/FreeImage/Source/OpenEXR/IlmImf/ImfAttribute.cpp b/src/FreeImage/Source/OpenEXR/IlmImf/ImfAttribute.cpp
+index feb5f83..5cb036e 100644
+--- a/src/FreeImage/Source/OpenEXR/IlmImf/ImfAttribute.cpp
++++ b/src/FreeImage/Source/OpenEXR/IlmImf/ImfAttribute.cpp
+@@ -61,7 +61,7 @@ Attribute::~Attribute () {}
+ 
+ namespace {
+ 
+-struct NameCompare: std::binary_function <const char *, const char *, bool>
++struct NameCompare
+ {
+     bool
+     operator () (const char *x, const char *y) const


### PR DESCRIPTION
This fixes build error `Error C2039 'binary_function': is not a member of 'std' ` in FreeImage/OpenEXR under latest Visual Studio 2022 See https://learn.microsoft.com/en-us/answers/questions/1348183/std-binary-function-is-missing-in-msvc-14-37-32822

I tried upgrading FreeImage to latest but it has the same issue (July 31st, 2018: FreeImage 3.18.0 released).
Note ours is pretty old (March 17th, 2012: FreeImage 3.15.3 released).

I ended up just deleting the offending code because it turned out to be deadcode (a `std::map` compare func has nothing to do with `binary_function`).